### PR TITLE
Fixed IndexOutOfBounds exception when adding a new auto login account.

### DIFF
--- a/SAM/MainWindow.xaml.cs
+++ b/SAM/MainWindow.xaml.cs
@@ -1110,12 +1110,12 @@ namespace SAM
                 // If the auto login checkbox was checked, update settings file and global variables. 
                 if (dialog.AutoLogAccountIndex == true)
                 {
-                    settings.File.Write(SAMSettings.SELECTED_ACCOUNT_INDEX, (encryptedAccounts.Count + 1).ToString(), SAMSettings.SECTION_AUTOLOG);
+                    settings.File.Write(SAMSettings.SELECTED_ACCOUNT_INDEX, (encryptedAccounts.Count).ToString(), SAMSettings.SECTION_AUTOLOG);
                     settings.File.Write(SAMSettings.LOGIN_SELECTED_ACCOUNT, true.ToString(), SAMSettings.SECTION_AUTOLOG);
                     settings.File.Write(SAMSettings.LOGIN_RECENT_ACCOUNT, false.ToString(), SAMSettings.SECTION_AUTOLOG);
                     settings.User.LoginSelectedAccount = true;
                     settings.User.LoginRecentAccount = false;
-                    settings.User.SelectedAccountIndex = encryptedAccounts.Count + 1;
+                    settings.User.SelectedAccountIndex = encryptedAccounts.Count;
                 }
 
                 try
@@ -2541,9 +2541,12 @@ namespace SAM
 
             try
             {
-                Process SteamProc = Process.GetProcessesByName("Steam")[0];
-                Process.Start(stopInfo);
-                SteamProc.WaitForExit();
+                Process SteamProc = Process.GetProcessesByName("Steam").FirstOrDefault();
+                if(SteamProc != null)
+                {
+                    Process.Start(stopInfo);
+                    SteamProc.WaitForExit();
+                }
             }
             catch
             {


### PR DESCRIPTION
Fixed IndexOutOfBounds exception when adding a new auto login account.
Fixed IndexOutOfBounds exception when trying to shutdown Steam when no steam process is running.