### PR TITLE
Temp fix for Steam React Login UI

### DIFF
--- a/Views/AccountsWindow.xaml.cs
+++ b/Views/AccountsWindow.xaml.cs
@@ -1308,7 +1308,7 @@ namespace SAM.Views
                 UseShellExecute = true,
                 FileName = settings.User.SteamPath + "steam.exe",
                 WorkingDirectory = settings.User.SteamPath,
-                Arguments = parametersBuilder.ToString()
+                Arguments = "-noreactlogin " + parametersBuilder.ToString()
             };
 
             try


### PR DESCRIPTION
This temporarily fixes the account manager from not working on the newer React based Steam Login prompt by forcing back to the old UI.