### PR TITLE
allow users to switch between login prompt versions

### DIFF
--- a/Core/SAMSettings.cs
+++ b/Core/SAMSettings.cs
@@ -69,6 +69,7 @@ namespace SAM.Core
         public const string SINGLE_CORE_PARAMETER = "single_core";
         public const string TCP_PARAMETER = "tcp";
         public const string TEN_FOOT_PARAMETER = "tenfoot";
+        public const string NO_REACT_LOGIN_PARAMETER = "noreactlogin";
         public const string CUSTOM_PARAMETERS = "customParameters";
         public const string CUSTOM_PARAMETERS_VALUE = "customParametersValue";
 
@@ -141,6 +142,7 @@ namespace SAM.Core
             { SINGLE_CORE_PARAMETER, SECTION_PARAMETERS },
             { TCP_PARAMETER, SECTION_PARAMETERS },
             { TEN_FOOT_PARAMETER, SECTION_PARAMETERS },
+            { NO_REACT_LOGIN_PARAMETER, SECTION_PARAMETERS },
             { CUSTOM_PARAMETERS, SECTION_PARAMETERS },
             { CUSTOM_PARAMETERS_VALUE, SECTION_PARAMETERS },
 

--- a/Core/UserSettings.cs
+++ b/Core/UserSettings.cs
@@ -87,6 +87,8 @@ namespace SAM.Core
         public bool SingleCore { get { return (bool)KeyValuePairs[SAMSettings.SINGLE_CORE_PARAMETER]; } set { KeyValuePairs[SAMSettings.SINGLE_CORE_PARAMETER] = value; } }
         public bool TCP { get { return (bool)KeyValuePairs[SAMSettings.TCP_PARAMETER]; } set { KeyValuePairs[SAMSettings.TCP_PARAMETER] = value; } }
         public bool TenFoot { get { return (bool)KeyValuePairs[SAMSettings.TEN_FOOT_PARAMETER]; } set { KeyValuePairs[SAMSettings.TEN_FOOT_PARAMETER] = value; } }
+
+        public bool NoReactLogin { get { return (bool)KeyValuePairs[SAMSettings.NO_REACT_LOGIN_PARAMETER]; } set { KeyValuePairs[SAMSettings.NO_REACT_LOGIN_PARAMETER] = value; } }
         public bool CustomParameters { get { return (bool)KeyValuePairs[SAMSettings.CUSTOM_PARAMETERS]; } set { KeyValuePairs[SAMSettings.CUSTOM_PARAMETERS] = value; } }
         public string CustomParametersValue { get { return (string)KeyValuePairs[SAMSettings.CUSTOM_PARAMETERS_VALUE]; } set { KeyValuePairs[SAMSettings.CUSTOM_PARAMETERS_VALUE] = value; } }
 
@@ -166,6 +168,7 @@ namespace SAM.Core
             { SAMSettings.SINGLE_CORE_PARAMETER, false },
             { SAMSettings.TCP_PARAMETER, false },
             { SAMSettings.TEN_FOOT_PARAMETER, false },
+            { SAMSettings.NO_REACT_LOGIN_PARAMETER, false },
             { SAMSettings.CUSTOM_PARAMETERS, false },
             { SAMSettings.CUSTOM_PARAMETERS_VALUE, string.Empty },
 

--- a/Core/Utils.cs
+++ b/Core/Utils.cs
@@ -17,6 +17,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
 using SAM.Views;
+using ControlzEx.Standard;
 
 namespace SAM.Core
 {
@@ -55,6 +56,8 @@ namespace SAM.Core
         public const int VK_RETURN = 0x0D;
         public const int VK_TAB = 0x09;
         public const int VK_SPACE = 0x20;
+        public const int WM_LBUTTONDOWN = 0x0201;
+        public const int WM_LBUTTONUP = 0x0202;
 
         public static int API_KEY_LENGTH = 32;
         readonly static char[] specialChars = { '{', '}', '(', ')', '[', ']', '+', '^', '%', '~' };
@@ -713,7 +716,34 @@ namespace SAM.Core
             wh.GetClassName().Equals("vguiPopupWindow") &&
             (wh.GetWindowText().StartsWith("Steam Guard") ||
              wh.GetWindowText().StartsWith("Steam 令牌") ||
-             wh.GetWindowText().StartsWith("Steam ガード")));
+             wh.GetWindowText().StartsWith("Steam ガード") ||
+             // fix the window detection for the new react based login prompt, i added all these whilst Mimi was falling asleep and im super tired and sleepy as well, these are located in "steamui_LANG.txt" where LANG is the language - Killa 23/11/2022
+             wh.GetWindowText().StartsWith("Steamサインイン") ||
+             wh.GetWindowText().StartsWith("Iniciar a sessão no Steam") ||
+             wh.GetWindowText().StartsWith("Steam вписване") ||
+             wh.GetWindowText().StartsWith("Přihlášení do služby Steam") ||
+             wh.GetWindowText().StartsWith("Steam-login") ||
+             wh.GetWindowText().StartsWith("Aanmelden bij Steam") ||
+             wh.GetWindowText().StartsWith("Steam Sign In") ||
+             wh.GetWindowText().StartsWith("Kirjautuminen Steamiin") ||
+             wh.GetWindowText().StartsWith("Connexion à Steam") ||
+             wh.GetWindowText().StartsWith("Steam-Anmeldung") ||
+             wh.GetWindowText().StartsWith("Σύνδεση στο Steam") ||
+             wh.GetWindowText().StartsWith("Steam bejelentkezés") ||
+             wh.GetWindowText().StartsWith("Accesso a Steam") ||
+             wh.GetWindowText().StartsWith("Steamサインイン") ||
+             wh.GetWindowText().StartsWith("Steam 로그인") ||
+             wh.GetWindowText().StartsWith("Inicio de sesión en Steam") ||
+             wh.GetWindowText().StartsWith("Steam Ship Embarkation") ||
+             wh.GetWindowText().StartsWith("Iniciar sessão no Steam") ||
+             wh.GetWindowText().StartsWith("Вход в Steam") ||
+             wh.GetWindowText().StartsWith("Steam 登录") ||
+             wh.GetWindowText().StartsWith("Inloggning på Steam") ||
+             wh.GetWindowText().StartsWith("การเข้าสู่ระบบ Steam") ||
+             wh.GetWindowText().StartsWith("Вхід у Steam") ||
+             wh.GetWindowText().StartsWith("Đăng nhập Steam")
+
+             ));
             return windowHandle;
         }
 
@@ -823,6 +853,12 @@ namespace SAM.Core
             // Press key up
             keybd_event((byte)System.Windows.Forms.Keys.CapsLock, 0, 0x2, 0);
         }
+
+
+
+
+
+
 
         public static void SendCharacter(IntPtr hwnd, VirtualInputMethod inputMethod, char c)
         {

--- a/Core/Utils.cs
+++ b/Core/Utils.cs
@@ -17,7 +17,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
 using SAM.Views;
-using ControlzEx.Standard;
 
 namespace SAM.Core
 {
@@ -56,8 +55,6 @@ namespace SAM.Core
         public const int VK_RETURN = 0x0D;
         public const int VK_TAB = 0x09;
         public const int VK_SPACE = 0x20;
-        public const int WM_LBUTTONDOWN = 0x0201;
-        public const int WM_LBUTTONUP = 0x0202;
 
         public static int API_KEY_LENGTH = 32;
         readonly static char[] specialChars = { '{', '}', '(', ')', '[', ']', '+', '^', '%', '~' };
@@ -853,12 +850,6 @@ namespace SAM.Core
             // Press key up
             keybd_event((byte)System.Windows.Forms.Keys.CapsLock, 0, 0x2, 0);
         }
-
-
-
-
-
-
 
         public static void SendCharacter(IntPtr hwnd, VirtualInputMethod inputMethod, char c)
         {

--- a/Views/AccountsWindow.xaml.cs
+++ b/Views/AccountsWindow.xaml.cs
@@ -1364,7 +1364,7 @@ namespace SAM.Views
                 UseShellExecute = true,
                 FileName = settings.User.SteamPath + "steam.exe",
                 WorkingDirectory = settings.User.SteamPath,
-                Arguments = "-noreactlogin " + parametersBuilder.ToString()
+                Arguments = parametersBuilder.ToString()
             };
 
             try

--- a/Views/AccountsWindow.xaml.cs
+++ b/Views/AccountsWindow.xaml.cs
@@ -1562,6 +1562,9 @@ namespace SAM.Views
             }
 
             Thread.Sleep(100);
+            //send tab twice, should work for old and new UI
+            Core.Utils.SendTab(steamLoginWindow.RawPtr, settings.User.VirtualInputMethod);
+            Core.Utils.SendTab(steamLoginWindow.RawPtr, settings.User.VirtualInputMethod);
 
             foreach (char c in Generate2FACode(decryptedAccounts[index].SharedSecret).ToCharArray())
             {

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -138,9 +138,11 @@
                     <CheckBox x:Name="SingleCoreCheckBox" Content="-single__core" HorizontalAlignment="Left" Margin="203,75,0,0" VerticalAlignment="Top" ToolTip="Force Steam to run on your primary CPU only."/>
                     <CheckBox x:Name="TcpCheckBox" Content="-tcp" HorizontalAlignment="Left" Margin="203,98,0,0" VerticalAlignment="Top" ToolTip="Forces connection to Steam backend to be via TCP."/>
                     <CheckBox x:Name="TenFootCheckBox" Content="-tenfoot" HorizontalAlignment="Left" Margin="203,121,0,0" VerticalAlignment="Top" ToolTip="Start Steam in Big Picture Mode."/>
-                    <CheckBox x:Name="CustomParametersCheckBox" Content="" HorizontalAlignment="Left" Margin="12,150,0,0" VerticalAlignment="Top" Foreground="#FFD1D1D1" Checked="CustomParametersCheckBox_Checked" Unchecked="CustomParametersCheckBox_Unchecked" ToolTip="Toggle custom parameters"/>
-                    <TextBox x:Name="CustomParametersTextBox" HorizontalAlignment="Center" Height="19" Margin="33,146,35,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="266" IsEnabled="False"/>
+                    <CheckBox x:Name="NoReactLoginCheckBox" Content="-noreactlogin" HorizontalAlignment="Left" Margin="12,141,0,0" VerticalAlignment="Top" ToolTip="Start Steam with the Old Login UI"/>
+                    <CheckBox x:Name="CustomParametersCheckBox" Content="" HorizontalAlignment="Left" Margin="12,163,0,0" VerticalAlignment="Top" Foreground="#FFD1D1D1" Checked="CustomParametersCheckBox_Checked" Unchecked="CustomParametersCheckBox_Unchecked" ToolTip="Toggle custom parameters"/>
+                    <TextBox x:Name="CustomParametersTextBox" HorizontalAlignment="Center" Height="19" Margin="0,159,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="266" IsEnabled="False"/>
                     <Button x:Name="CustomParamsHelpButton" Content="?" Margin="0,146,8,13" Height="23" Width="25" HorizontalAlignment="Right" ToolTip="Online documentation" Click="CustomParamsHelpButton_Click"/>
+                    
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -499,7 +499,7 @@ namespace SAM.Views
             SingleCoreCheckBox.IsChecked = settings.Default.SingleCore;
             TcpCheckBox.IsChecked = settings.Default.TCP;
             TenFootCheckBox.IsChecked = settings.Default.TenFoot;
-            NoReactLoginCheckBox.IsChecked = settings.Default.TenFoot;
+            NoReactLoginCheckBox.IsChecked = settings.Default.NoReactLogin;
             CustomParametersCheckBox.IsChecked = settings.Default.CustomParameters;
             CustomParametersTextBox.Text = settings.Default.CustomParametersValue;
         }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -135,6 +135,48 @@ namespace SAM.Views
 
                     SetDefaultSettings();
                 }
+<<<<<<< Updated upstream
+=======
+                InputMethodSelectBox.SelectedItem = (VirtualInputMethod)Enum.Parse(typeof(VirtualInputMethod), settings.File.Read(SAMSettings.INPUT_METHOD, SAMSettings.SECTION_AUTOLOG));
+                HandleImeCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.HANDLE_IME, SAMSettings.SECTION_AUTOLOG));
+                SteamGuardOnlyCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.IME_2FA_ONLY, SAMSettings.SECTION_AUTOLOG));
+
+                // Customize
+                ThemeSelectBox.Text = settings.File.Read(SAMSettings.THEME, SAMSettings.SECTION_CUSTOMIZE);
+                AccentSelectBox.Text = settings.File.Read(SAMSettings.ACCENT, SAMSettings.SECTION_CUSTOMIZE);
+                buttonSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_SIZE, SAMSettings.SECTION_CUSTOMIZE);
+                ButtonColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_COLOR, SAMSettings.SECTION_CUSTOMIZE));
+                ButtonFontSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_FONT_SIZE, SAMSettings.SECTION_CUSTOMIZE);
+                ButtonFontColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_FONT_COLOR, SAMSettings.SECTION_CUSTOMIZE));
+                BannerColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_BANNER_COLOR, SAMSettings.SECTION_CUSTOMIZE));
+                BannerFontSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_BANNER_FONT_SIZE, SAMSettings.SECTION_CUSTOMIZE);
+                BannerFontColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_BANNER_FONT_COLOR, SAMSettings.SECTION_CUSTOMIZE));
+                HideBanIconsCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.HIDE_BAN_ICONS, SAMSettings.SECTION_CUSTOMIZE));
+
+                // Steam
+                SteamPathTextBox.Text = settings.File.Read(SAMSettings.STEAM_PATH, SAMSettings.SECTION_STEAM);
+                ApiKeyTextBox.Text = settings.File.Read(SAMSettings.STEAM_API_KEY, SAMSettings.SECTION_STEAM);
+                AutoReloadCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.AUTO_RELOAD_ENABLED, SAMSettings.SECTION_STEAM));
+                AutoReloadIntervalSpinBox.Text = settings.File.Read(SAMSettings.AUTO_RELOAD_INTERVAL, SAMSettings.SECTION_STEAM);
+
+                // Parameters
+                CafeAppLaunchCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CAFE_APP_LAUNCH_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                ClearBetaCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CLEAR_BETA_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                ConsoleCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CONSOLE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                LoginCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.LOGIN_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                DeveloperCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.DEVELOPER_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                ForceServiceCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                ConsoleCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                NoCacheCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                NoVerifyFilesCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.NO_VERIFY_FILES_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                SilentCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.SILENT_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                SingleCoreCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.SINGLE_CORE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                TcpCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.TCP_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                TenFootCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.TEN_FOOT_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                NoReactLoginCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.NO_REACT_LOGIN_PARAMETER, SAMSettings.SECTION_PARAMETERS));
+                CustomParametersCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CUSTOM_PARAMETERS, SAMSettings.SECTION_PARAMETERS));
+                CustomParametersTextBox.Text = settings.File.Read(SAMSettings.CUSTOM_PARAMETERS_VALUE, SAMSettings.SECTION_PARAMETERS);
+>>>>>>> Stashed changes
             }
         }
 
@@ -279,6 +321,7 @@ namespace SAM.Views
             settings.File.Write(SAMSettings.SINGLE_CORE_PARAMETER, SingleCoreCheckBox.IsChecked.ToString(), SAMSettings.SECTION_PARAMETERS);
             settings.File.Write(SAMSettings.TCP_PARAMETER, TcpCheckBox.IsChecked.ToString(), SAMSettings.SECTION_PARAMETERS);
             settings.File.Write(SAMSettings.TEN_FOOT_PARAMETER, TenFootCheckBox.IsChecked.ToString(), SAMSettings.SECTION_PARAMETERS);
+            settings.File.Write(SAMSettings.NO_REACT_LOGIN_PARAMETER, NoReactLoginCheckBox.IsChecked.ToString(), SAMSettings.SECTION_PARAMETERS);
             settings.File.Write(SAMSettings.CUSTOM_PARAMETERS, CustomParametersCheckBox.IsChecked.ToString(), SAMSettings.SECTION_PARAMETERS);
             settings.File.Write(SAMSettings.CUSTOM_PARAMETERS_VALUE, CustomParametersTextBox.Text, SAMSettings.SECTION_PARAMETERS);
         }
@@ -458,6 +501,7 @@ namespace SAM.Views
             SingleCoreCheckBox.IsChecked = settings.Default.SingleCore;
             TcpCheckBox.IsChecked = settings.Default.TCP;
             TenFootCheckBox.IsChecked = settings.Default.TenFoot;
+            NoReactLoginCheckBox.IsChecked = settings.Default.TenFoot;
             CustomParametersCheckBox.IsChecked = settings.Default.CustomParameters;
             CustomParametersTextBox.Text = settings.Default.CustomParametersValue;
         }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -135,8 +135,7 @@ namespace SAM.Views
 
                     SetDefaultSettings();
                 }
-<<<<<<< Updated upstream
-=======
+
                 InputMethodSelectBox.SelectedItem = (VirtualInputMethod)Enum.Parse(typeof(VirtualInputMethod), settings.File.Read(SAMSettings.INPUT_METHOD, SAMSettings.SECTION_AUTOLOG));
                 HandleImeCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.HANDLE_IME, SAMSettings.SECTION_AUTOLOG));
                 SteamGuardOnlyCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.IME_2FA_ONLY, SAMSettings.SECTION_AUTOLOG));
@@ -176,7 +175,6 @@ namespace SAM.Views
                 NoReactLoginCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.NO_REACT_LOGIN_PARAMETER, SAMSettings.SECTION_PARAMETERS));
                 CustomParametersCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CUSTOM_PARAMETERS, SAMSettings.SECTION_PARAMETERS));
                 CustomParametersTextBox.Text = settings.File.Read(SAMSettings.CUSTOM_PARAMETERS_VALUE, SAMSettings.SECTION_PARAMETERS);
->>>>>>> Stashed changes
             }
         }
 

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -135,46 +135,6 @@ namespace SAM.Views
 
                     SetDefaultSettings();
                 }
-
-                InputMethodSelectBox.SelectedItem = (VirtualInputMethod)Enum.Parse(typeof(VirtualInputMethod), settings.File.Read(SAMSettings.INPUT_METHOD, SAMSettings.SECTION_AUTOLOG));
-                HandleImeCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.HANDLE_IME, SAMSettings.SECTION_AUTOLOG));
-                SteamGuardOnlyCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.IME_2FA_ONLY, SAMSettings.SECTION_AUTOLOG));
-
-                // Customize
-                ThemeSelectBox.Text = settings.File.Read(SAMSettings.THEME, SAMSettings.SECTION_CUSTOMIZE);
-                AccentSelectBox.Text = settings.File.Read(SAMSettings.ACCENT, SAMSettings.SECTION_CUSTOMIZE);
-                buttonSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_SIZE, SAMSettings.SECTION_CUSTOMIZE);
-                ButtonColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_COLOR, SAMSettings.SECTION_CUSTOMIZE));
-                ButtonFontSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_FONT_SIZE, SAMSettings.SECTION_CUSTOMIZE);
-                ButtonFontColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_FONT_COLOR, SAMSettings.SECTION_CUSTOMIZE));
-                BannerColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_BANNER_COLOR, SAMSettings.SECTION_CUSTOMIZE));
-                BannerFontSizeSpinBox.Text = settings.File.Read(SAMSettings.BUTTON_BANNER_FONT_SIZE, SAMSettings.SECTION_CUSTOMIZE);
-                BannerFontColorPicker.SelectedColor = (Color)ColorConverter.ConvertFromString(settings.File.Read(SAMSettings.BUTTON_BANNER_FONT_COLOR, SAMSettings.SECTION_CUSTOMIZE));
-                HideBanIconsCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.HIDE_BAN_ICONS, SAMSettings.SECTION_CUSTOMIZE));
-
-                // Steam
-                SteamPathTextBox.Text = settings.File.Read(SAMSettings.STEAM_PATH, SAMSettings.SECTION_STEAM);
-                ApiKeyTextBox.Text = settings.File.Read(SAMSettings.STEAM_API_KEY, SAMSettings.SECTION_STEAM);
-                AutoReloadCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.AUTO_RELOAD_ENABLED, SAMSettings.SECTION_STEAM));
-                AutoReloadIntervalSpinBox.Text = settings.File.Read(SAMSettings.AUTO_RELOAD_INTERVAL, SAMSettings.SECTION_STEAM);
-
-                // Parameters
-                CafeAppLaunchCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CAFE_APP_LAUNCH_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                ClearBetaCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CLEAR_BETA_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                ConsoleCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CONSOLE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                LoginCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.LOGIN_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                DeveloperCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.DEVELOPER_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                ForceServiceCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                ConsoleCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                NoCacheCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.FORCE_SERVICE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                NoVerifyFilesCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.NO_VERIFY_FILES_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                SilentCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.SILENT_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                SingleCoreCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.SINGLE_CORE_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                TcpCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.TCP_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                TenFootCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.TEN_FOOT_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                NoReactLoginCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.NO_REACT_LOGIN_PARAMETER, SAMSettings.SECTION_PARAMETERS));
-                CustomParametersCheckBox.IsChecked = Convert.ToBoolean(settings.File.Read(SAMSettings.CUSTOM_PARAMETERS, SAMSettings.SECTION_PARAMETERS));
-                CustomParametersTextBox.Text = settings.File.Read(SAMSettings.CUSTOM_PARAMETERS_VALUE, SAMSettings.SECTION_PARAMETERS);
             }
         }
 


### PR DESCRIPTION
Valve has fixed command line options in the latest stable release of the Steam Client.

This PR allows the user to switch between the React based Steam Login UI Prompt (therefore allowing the user to easily login without having to enter a Steam Guard code by "approving" the login) or to alternatively switch back to the old non React based login prompt by the usage of a parameter checkbox.

