### PR TITLE
fixed crash due to Vdf Token being too large

### DIFF
--- a/Core/AccountUtils.cs
+++ b/Core/AccountUtils.cs
@@ -693,7 +693,10 @@ namespace SAM.Core
             }
             else
             {
-                localconfig = VdfConvert.Deserialize(File.ReadAllText(configFile));
+                VdfSerializerSettings vdfSerializerSettings = new VdfSerializerSettings();
+                vdfSerializerSettings.MaximumTokenSize = 4096 * 2;
+                vdfSerializerSettings.UsesEscapeSequences = true;
+                localconfig = VdfConvert.Deserialize(File.ReadAllText(configFile),vdfSerializerSettings);
             }
             
             dynamic configStore = localconfig.Value;


### PR DESCRIPTION
For me, the default max size causes the program to crash.
So I increased the maximum size

Line: 699 is because the default configuration also has that enabled and since I wanted to change as little as possible I recreated it